### PR TITLE
Allow for multi-repo cache

### DIFF
--- a/app/assets/js/review.service.js
+++ b/app/assets/js/review.service.js
@@ -26,7 +26,7 @@
         self.refresh = function (repo) {
             self.refreshing = true;
 
-            return $http.get('/api/reviews/' + repo + '/update').then(function (response) {
+            return $http.get('/api/reviews/update/' + repo).then(function (response) {
                 self.reviews(repo).then(function () {
                     self.refreshing = false;
                 });

--- a/models/review.rb
+++ b/models/review.rb
@@ -3,7 +3,19 @@ class Review
   include Mongoid::Document
   include Mongoid::Attributes::Dynamic
 
-  def self.index(repos)
+  def self.repos
+    [
+      'foreman',
+      'smart-proxy',
+      'theforeman.org',
+      'katello',
+      'foreman_discovery',
+    ]
+  end
+
+  def self.index(repos=nil)
+    repos = Review.repos if repos.nil?
+
     repos.each do |repo,repo_data|
       repo_data.each do |pull_data|
         pull_data['refreshed_on'] = Time.now

--- a/server/updates.rb
+++ b/server/updates.rb
@@ -36,7 +36,7 @@ get '/api/upstream/:project/trackers/update' do
   issues.to_json
 end
 
-get '/api/reviews/:repo/update' do
+get '/api/reviews/update/:repo' do
   pulls = PullRequest.get_reviews(params[:repo])
 
   Review.index(pulls)


### PR DESCRIPTION
Slight change in the API call so that we can leave off the :repo parameter if we want to refresh all of them. Added the whitelist as a class method so you can call it from the JS if you like :)
